### PR TITLE
Add fifty-fifty failing tests

### DIFF
--- a/fixture/fifty-fifty-space-first.js
+++ b/fixture/fifty-fifty-space-first.js
@@ -1,0 +1,4 @@
+    4 spaces
+    4 spaces
+	1 tab
+	1 tab

--- a/fixture/fifty-fifty-tab-first.js
+++ b/fixture/fifty-fifty-tab-first.js
@@ -1,0 +1,4 @@
+	1 tab
+	1 tab
+    4 spaces
+    4 spaces

--- a/test.js
+++ b/test.js
@@ -96,7 +96,7 @@ test('return indentation stats for no indentation', t => {
 	});
 });
 
-test('return indentation stats for fifty-fifty indented files with spaces first', t => {
+test.failing('return indentation stats for fifty-fifty indented files with spaces first', t => {
 	const stats = m(getFile('fixture/fifty-fifty-space-first.js'));
 	t.deepEqual(stats, {
 		amount: 4,
@@ -105,7 +105,7 @@ test('return indentation stats for fifty-fifty indented files with spaces first'
 	});
 });
 
-test('return indentation stats for fifty-fifty indented files with tabs first', t => {
+test.failing('return indentation stats for fifty-fifty indented files with tabs first', t => {
 	const stats = m(getFile('fixture/fifty-fifty-tab-first.js'));
 	t.deepEqual(stats, {
 		amount: 4,

--- a/test.js
+++ b/test.js
@@ -95,3 +95,21 @@ test('return indentation stats for no indentation', t => {
 		type: null
 	});
 });
+
+test('return indentation stats for fifty-fifty indented files with spaces first', t => {
+	const stats = m(getFile('fixture/fifty-fifty-space-first.js'));
+	t.deepEqual(stats, {
+		amount: 4,
+		indent: '    ',
+		type: 'space'
+	});
+});
+
+test('return indentation stats for fifty-fifty indented files with tabs first', t => {
+	const stats = m(getFile('fixture/fifty-fifty-tab-first.js'));
+	t.deepEqual(stats, {
+		amount: 4,
+		indent: '    ',
+		type: 'space'
+	});
+});


### PR DESCRIPTION
I saw #15 and though to give it a go. It seems harder than expected.

So what I noticed is that we get different results when we do tabs first and then spaces or vice versa.

## Spaces first

Test case

```
    4 spaces
    4 spaces
	1 tab
	1 tab
```

The `indents` map looks like this

```
Map { 4 => [ 1, 1 ], -3 => [ 1, 0 ] }
```

And the result is

```
{amount:4,type:"space",indent:"    "}
```

Result: OK

#### But...

If I change the test case to this

```
    4 spaces
    4 spaces
	1 tab
	1 tab
	1 tab
```

Now the result looks like this:

```js
{amount:4,type:"tab",indent:"\t\t\t\t"}
```

The reason is that it takes the highest amounts of indents (being tabs) and repeats that with the result of [`getMostUsed(indents)`](https://github.com/sindresorhus/detect-indent/blob/master/index.js#L102) which returns `4`.

Result: incorrect

## Tabs first

Test case

```
	1 tab
	1 tab
    4 spaces
    4 spaces
```

The `indents` map looks like this

```
Map { 1 => [ 1, 1 ], 3 => [ 1, 1 ] }
```

Because of [this](https://github.com/sindresorhus/detect-indent/blob/master/index.js#L109-L112) check, it picks `space` as type and repeats that with the result of [`getMostUsed(indents)`](https://github.com/sindresorhus/detect-indent/blob/master/index.js#L102) which returns `1`.

Result: incorrect

#### But...

Let's also add an extra 4 spaces line

```
	1 tab
	1 tab
    4 spaces
    4 spaces
    4 spaces
```

This results in the `indents` map being

```
Map { 1 => [ 1, 1 ], 3 => [ 1, 2 ] }
```

And results in the following

```
{amount:3,type:"space",indent:"   "}
```

Result: incorrect

------------------
I have to dig deeper into the algorithm to find out how we can fix these. Just wanted to share my findings until now.