### PR TITLE
Fix detection when string has equal amount of tabs and spaces

### DIFF
--- a/fixture/space-tab-last.js
+++ b/fixture/space-tab-last.js
@@ -1,0 +1,5 @@
+    4 spaces
+    4 spaces
+	1 tab
+	1 tab
+	1 tab

--- a/test.js
+++ b/test.js
@@ -103,11 +103,20 @@ test('return indentation stats for fifty-fifty indented files with spaces first'
 	});
 });
 
-test.failing('return indentation stats for fifty-fifty indented files with tabs first', t => {
+test('return indentation stats for fifty-fifty indented files with tabs first', t => {
 	const stats = m(getFile('fixture/fifty-fifty-tab-first.js'));
 	t.deepEqual(stats, {
-		amount: 4,
-		indent: '    ',
-		type: 'space'
+		amount: 1,
+		indent: '	',
+		type: 'tab'
+	});
+});
+
+test('return indentation stats for indented files with spaces and tabs last', t => {
+	const stats = m(getFile('fixture/space-tab-last.js'));
+	t.deepEqual(stats, {
+		amount: 1,
+		indent: '	',
+		type: 'tab'
 	});
 });


### PR DESCRIPTION
Based on #15 and #21 I refactored the code and added a new test to fix the issues.

Previously when the number of spaces was the same as the number of tabs, spaces had precedence but now the algorithm will use the first with the most occurence/weight.

Fixes #15